### PR TITLE
Arregla el que se borren todas las tareas con una sola petición DELETE

### DIFF
--- a/server/tasks/tasks.controller.js
+++ b/server/tasks/tasks.controller.js
@@ -115,7 +115,7 @@ function deleteTask(req, res) {
                     message: 'No hay tareas'
                 });
             } else{
-                Task.remove(err => {
+                task.remove(err => {
                     if (err) {
                         res.status(500).send({
                             message: 'Error al borrar la tarea',


### PR DESCRIPTION
Sin querer estabas llamando al modelo en vez de a la tarea que te devolvía. Esto hace que borre todas las tareas de la colección en vez de la que le estás pasando la id, que es la que te devuelve al principio del callback.